### PR TITLE
use d3 modules in docs

### DIFF
--- a/docs/docs.jsx
+++ b/docs/docs.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Ecology from 'ecology';
 import Radium, { Style } from 'radium';
+import d3Scale from "d3-scale";
 import * as docgen from "react-docgen";
 
 import {VictoryTheme} from 'formidable-landers';
@@ -14,7 +15,7 @@ class Docs extends React.Component {
         <Ecology
           overview={require('!!raw!./ecology.md')}
           source={docgen.parse(require("!!raw!../src/components/victory-axis"))}
-          scope={{React, ReactDOM, VictoryAxis: require('../src/components/victory-axis')}}
+          scope={{React, ReactDOM, d3Scale, VictoryAxis: require('../src/components/victory-axis')}}
           playgroundtheme='elegant' />
         <Style rules={VictoryTheme}/>
       </div>

--- a/docs/ecology.md
+++ b/docs/ecology.md
@@ -82,27 +82,29 @@ The sensible defaults VictoryAxis provides make it easy to get started, but ever
 
 ### Non-linear scales
 
-With a little more code, you can make a time scale axis with custom tick values and formatting. 
+With a little more code, you can make a time scale axis with custom tick values and formatting.
 
 ```playground
 <VictoryAxis
-  scale={d3.time.scale()}
+  scale={d3Scale.time()}
   tickValues={[
     new Date(1980, 1, 1),
     new Date(1990, 1, 1),
     new Date(2000, 1, 1),
     new Date(2010, 1, 1),
     new Date(2020, 1, 1)]}
-    tickFormat={d3.time.format("%Y")}/>
+    tickFormat={(x) => x.getFullYear()}/>
 ```
 
 Here's how you make a log scale:
 
 ```playground
-<VictoryAxis dependentAxis
-  scale={d3.scale.log()}
-  offsetX={75}
-  domain={[1, 5]}/>
+<VictoryAxis
+  dependentAxis
+  padding={{left: 50, top: 20, bottom: 20}}
+  scale={d3Scale.log()}
+  domain={[1, 5]}
+/>
 ```
 
 ### Animating


### PR DESCRIPTION
no review

this adds d3Scale to the docs scope instead of d3

fixes #62
